### PR TITLE
Fix no-title, no-descrip embed case

### DIFF
--- a/src/translators/embeds.js
+++ b/src/translators/embeds.js
@@ -16,13 +16,16 @@ async function handleMessage(logger, translate, message) {
 
         let possibleLang = ""
         let missingDescription = false
-        
+
         if (embed.description) {
             possibleLang = await detectionService.detectLanguage(embed.description)
         } else if (embed.title) {
             // Sets conditional flags for triggering the msg reply
             possibleLang = await detectionService.detectLanguage(embed.title)
             missingDescription = true
+        } else {
+            logger.debug('[EMBED] No-op embed detected, returning early.')
+            return
         }
 
         logger.debug(`[EMBED] Language is suspected to be: ${possibleLang}`)


### PR DESCRIPTION
Didn't cover the case where both the embed's title and description are undefined, so adding an else block here to cover the all-fail situation.