### PR TITLE
Fix emoji char false translate

### DIFF
--- a/src/translators/embeds.js
+++ b/src/translators/embeds.js
@@ -30,7 +30,7 @@ async function handleMessage(logger, translate, message) {
         }
 
         logger.debug(`[EMBED] Language is suspected to be: ${possibleLang}`)
-        if (possibleLang == 'en' || possibleLang == 'und') {
+        if (possibleLang == 'en' || possibleLang == 'und' || possibleLang == 'null') {
             return
         } else if (missingDescription) {
             message.reply({ content: `Sorry friend, but ${embed.title} has no description so there is nothing I can translate here.`})

--- a/src/translators/twitter.js
+++ b/src/translators/twitter.js
@@ -79,8 +79,6 @@ async function translateAndSend(logger, translate, message, data) {
         const detectionService = new DetectionService(process.env.DL_KEY)
 
         // Process language metadata and decide on source language
-        // TODO: Maybe fix this later and see if we can smartly choose the source language without hitting detection API
-        // let possibleLang = jsonResponse.lang !== 'en' ? jsonResponse.lang : await detectionService.detectLanguage(jsonResponse.full_text)
         let possibleLang = null 
         try {
           if (detectionService.isMaybeEnglishOffline(jsonResponse.full_text)) {
@@ -89,7 +87,8 @@ async function translateAndSend(logger, translate, message, data) {
             possibleLang = await detectionService.detectLanguage(jsonResponse.full_text)
           }
           logger.debug(`[TWITTER] Language is suspected to be: ${possibleLang}`)
-          if (possibleLang == 'en' || possibleLang == 'und') {
+          // und and null seem to mean the service couldn't quite figure itself out. We will black hole these along with ignoring english.
+          if (possibleLang == 'en' || possibleLang == 'und' || possibleLang == 'null') {
             return
           }
         } catch (e) {

--- a/src/translators/twitter.js
+++ b/src/translators/twitter.js
@@ -103,6 +103,13 @@ async function translateAndSend(logger, translate, message, data) {
         
         translate.translate(tweets.full_text, 'en').then(res => {
           var translated = res[1].data.translations[0]
+
+          var language = iso6391.getName(translated.detectedSourceLanguage)
+          // If Google doesn't give us an discernible iso code (ex - iw is no longer used), fallback to what twitter might tell us.
+          if (language == "") {
+            language = iso6391.getName(possibleLang)
+          }
+
           var embed = new Discord.MessageEmbed()
             .setColor(0x00afff)
             .setAuthor(
@@ -115,7 +122,7 @@ async function translateAndSend(logger, translate, message, data) {
               "____________________",
               dateUtils.prettyPrintDate(jsonResponse.created_at)
             )
-            .setFooter('Translated from '+iso6391.getName(translated.detectedSourceLanguage)+' with love by CodeMonkey')
+            .setFooter('Translated from '+language+' with love by CodeMonkey')
 
           message.reply({ embeds: [embed]})
           logger.info('[TRANSLATION] server='+message.channel.guild.name+', source=twitter, srcLanguage='+possibleLang+', user='+jsonResponse.user.screen_name+', id='+jsonResponse.id_str)


### PR DESCRIPTION
detectLanguage can return a 'null' as the detected language when the text is mostly unicode or links. Catching this case and returning early seems to address false translations mostly.