### PR TITLE
containsAnyLink should not be newline anchored

### DIFF
--- a/src/utils/link-parser.js
+++ b/src/utils/link-parser.js
@@ -16,7 +16,7 @@ function containsOnlyLink(text) {
 }
 
 function containsAnyLink(text) {
-  var regexOnlyUrl = /^(?<!\>.+)((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=\+\$,\w]+@)?[A-Za-z0-9.-]+|(?:www.|[-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:\/[\+~%\/.\w-_]*)?\??(?:[-\+=&;%@.\w_]*)#?(?:[\w]*))?)/
+  var regexOnlyUrl = /(?<!\>.+)((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=\+\$,\w]+@)?[A-Za-z0-9.-]+|(?:www.|[-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:\/[\+~%\/.\w-_]*)?\??(?:[-\+=&;%@.\w_]*)#?(?:[\w]*))?)/
   while((matchItem = regexOnlyUrl.exec(text)) != null) {
     if ( matchItem[0] ) return true
   }


### PR DESCRIPTION
Copy pasta spilled the beginning-line anchor into the containsAnyLink function, breaking it's intended functionality.

This change should allow folks to have text before the embed-generating link, and still get a translation.

This change will require monitoring, as it could increase the number of detection events and possibly the more expensive translations.