### PR TITLE
Upgrades to Twitter Translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,11 @@ The bot will rely on a few environment variables being available to work properl
 | Google Cloud Project ID | GOOGLE_PROJECT_ID | --- |
 | Google Cloud Client Email | GOOGLE_CLIENT_EMAIL | --- |
 | Google Cloud Client Key | GOOGLE_CLIENT_KEY | --- |
-| Twitter Consumer Key | TWITTER_CONSUMER_KEY | --- |
-| Twitter Secret Key | TWITTER_SECRET_KEY | --- |
 | Twitter Bearer Token | TWITTER_BEARER_TOKEN | --- |
 | DetectLanguage API Key | DL_KEY | https://detectlanguage.com/ | 
 
 The bot can be run with 
-`DISCORD_TRANSLATE_TOKEN=$DISCORD_TRANSLATE_TOKEN DL_KEY=$DL_KEY GOOGLE_PROJECT_ID=$GOOGLE_PROJECT_ID GOOGLE_CLIENT_EMAIL=$GOOGLE_CLIENT_EMAIL GOOGLE_CLIENT_KEY=$GOOGLE_CLIENT_KEY GOOGLE_TRANSLATE_KEY=$GOOGLE_TRANSLATE_KEY TWITTER_BEARER_TOKEN=$TWITTER_BEARER_TOKEN TWITTER_CONSUMER_KEY=$TWITTER_CONSUMER_KEY TWITTER_SECRET_KEY=$TWITTER_SECRET_KEY node src/app.js`
+`DISCORD_TRANSLATE_TOKEN=$DISCORD_TRANSLATE_TOKEN DL_KEY=$DL_KEY GOOGLE_PROJECT_ID=$GOOGLE_PROJECT_ID GOOGLE_CLIENT_EMAIL=$GOOGLE_CLIENT_EMAIL GOOGLE_CLIENT_KEY=$GOOGLE_CLIENT_KEY GOOGLE_TRANSLATE_KEY=$GOOGLE_TRANSLATE_KEY TWITTER_BEARER_TOKEN=$TWITTER_BEARER_TOKEN node src/app.js`
 
 ### Configuration values
 All configurations for the bot are kept in src/config/config.json (except the log format). There is an example-config.json you can copy to get started, but tune parameters as needed for logging and such.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "languagedetect": "^2.0.0",
     "limiter": "^2.1.0",
     "translate": "^1.2.3",
-    "twitter": "^1.7.1",
+    "twitter-api-v2": "^1.14.0",
     "winston": "^3.3.3"
   },
   "devDependencies": {

--- a/src/translators/twitter.js
+++ b/src/translators/twitter.js
@@ -1,4 +1,5 @@
-var Twitter = require('twitter');
+const { TwitterApi } = require('twitter-api-v2');
+const util = require('util');
 var dateUtils = require('../utils/date-utils');
 var linkParser = require('../utils/link-parser');
 var iso6391 = require('iso-639-1');
@@ -8,11 +9,7 @@ const DetectionService = require('../services/detection');
 /**
  * Setup twitter client so we can talk to twitter API
  */
-const twitter = new Twitter({
-    consumer_key: process.env.TWITTER_CONSUMER_KEY,
-    consumer_secret: process.env.TWITTER_SECRET_KEY,
-    bearer_token: process.env.TWITTER_BEARER_TOKEN
-})
+const twitter = new TwitterApi(process.env.TWITTER_BEARER_TOKEN);
   
 /**
  * getDistinctTwitterLinksInContent is self explanatory. It literally checks a message and if it has a twitter link, it extracts it.
@@ -64,79 +61,97 @@ function handleMessage(logger, translate, message) {
   Meat and taters function
 */
 async function translateAndSend(logger, translate, message, data) {
-    twitter.get(`statuses/show.json?id=` + data.status_id, { tweet_mode:"extended"}, async function(error, tweets, response) {
-      if(error) {
-        logger.error("Error communicating with twitter: "+error);
-       } else {
-        
-        var jsonResponse = tweets
-  
-        if ( linkParser.containsOnlyLink(jsonResponse.full_text) ) {
-          logger.debug("Tweet contains only a link, ignoring.")
-          return
-        }
+  console.log(data.status_id)
 
-        const detectionService = new DetectionService(process.env.DL_KEY)
+  const response = await twitter.v2.singleTweet(data.status_id, {
+    'expansions': [
+      'author_id'
+    ],
+    'user.fields': [
+      'name',
+      'profile_image_url'
+    ],
+    'tweet.fields': [
+      'created_at',
+      'lang'
+    ]
+  });
+  //console.log(util.inspect(response, {depth: null}))
 
-        // Process language metadata and decide on source language
-        let possibleLang = null 
-        try {
-          if (detectionService.isMaybeEnglishOffline(jsonResponse.full_text)) {
-            possibleLang = 'en'
-          } else {
-            possibleLang = await detectionService.detectLanguage(jsonResponse.full_text)
-          }
-          logger.debug(`[TWITTER] Language is suspected to be: ${possibleLang}`)
-          
-          // und seems to mean the service couldn't quite figure itself out. We will black hole these along with ignoring english.
-          if (possibleLang == 'en' || possibleLang == 'und') {
-            return
-          }
-        } catch (e) {
-          if (e == "UNRELIABLE") {
-            message.reply({ content: `the language detection was unreliable so I can't do anything here. Please report it if you have concerns.`}).then(msg => {
-              msg.delete({timeout: 10000})
-            })
-            return
-          } else if (e == "NO_DETECTION") {
-            logger.warn("Translation service did not detect any language, assuming it was a no-op.")
-            return
-          }
-        }
-        
-        translate.translate(tweets.full_text, 'en').then(res => {
-          var translated = res[1].data.translations[0]
+  const tweetData = response.data
+  const userData = response.includes.users[0]
 
-          if (translated.detectedSourceLanguage == 'en') {
-            logger.error("GCT thinks this is already English, so we wasted a translation.")
-            return
-          }
+  const tweetText = tweetData.text
 
-          var language = iso6391.getName(translated.detectedSourceLanguage)
-          // If Google doesn't give us an discernible iso code (ex - iw is no longer used), fallback to what twitter might tell us.
-          if (language == "") {
-            language = iso6391.getName(possibleLang)
-          }
-
-          const embed = new EmbedBuilder()
-            .setColor(0x00afff)
-            .setAuthor({
-              name: jsonResponse.user.name + " (@" + jsonResponse.user.screen_name + ")",
-              iconURL: jsonResponse.user.profile_image_url,
-              url: "https://twitter.com/" + jsonResponse.user.screen_name + "/status/" + jsonResponse.id_str
-            })
-            .setDescription(translated.translatedText)
-            .addFields(
-              { name: "Published On", value: dateUtils.prettyPrintDate(jsonResponse.created_at) }
-            )
-            .setFooter({ text: 'Translated from '+language+' with love by CodeMonkey'})
-
-          message.reply({ embeds: [embed]})
-          logger.info('[TRANSLATION] server='+message.channel.guild.name+', source=twitter, srcLanguage='+language+', user='+jsonResponse.user.screen_name+', id='+jsonResponse.id_str)
-        })
-       }
-    })
+  if ( linkParser.containsOnlyLink(tweetText) ) {
+    logger.debug("Tweet contains only a link, ignoring.")
+    return
   }
+
+  const detectionService = new DetectionService(process.env.DL_KEY)
+
+  /**
+  // Process language metadata and decide on source language
+  let possibleLang = tweetData.lang
+  try {
+    if (detectionService.isMaybeEnglishOffline(tweetText)) {
+      possibleLang = 'en'
+    } else {
+      possibleLang = await detectionService.detectLanguage(tweetText)
+    }
+    logger.debug(`[TWITTER] Language is suspected to be: ${possibleLang}`)
+    
+    // und seems to mean the service couldn't quite figure itself out. We will black hole these along with ignoring english.
+    if (possibleLang == 'en' || possibleLang == 'und') {
+      return
+    }
+  } catch (e) {
+    if (e == "UNRELIABLE") {
+      message.reply({ content: `the language detection was unreliable so I can't do anything here. Please report it if you have concerns.`}).then(msg => {
+        msg.delete({timeout: 10000})
+      })
+      return
+    } else if (e == "NO_DETECTION") {
+      logger.warn("Translation service did not detect any language, assuming it was a no-op.")
+      return
+    }
+  }
+  */
+
+  // WIP - New guard clause to remove english tweets
+  if (tweetData.lang == 'en') { return }
+
+  translate.translate(tweetText, 'en').then(res => {
+    var translated = res[1].data.translations[0]
+
+    if (translated.detectedSourceLanguage == 'en') {
+      logger.error("GCT thinks this is already English, so we wasted a translation.")
+      return
+    }
+
+    var language = iso6391.getName(translated.detectedSourceLanguage)
+    // If Google doesn't give us an discernible iso code (ex - iw is no longer used), fallback to what twitter might tell us.
+    if (language == "") {
+      language = iso6391.getName(possibleLang)
+    }
+
+    const embed = new EmbedBuilder()
+      .setColor(0x00afff)
+      .setAuthor({
+        name: userData.name + " (@" + userData.username + ")",
+        iconURL: userData.profile_image_url,
+        url: "https://twitter.com/" + userData.username + "/status/" + tweetData.id
+      })
+      .setDescription(translated.translatedText)
+      .addFields(
+        { name: "Published On", value: dateUtils.prettyPrintDate(tweetData.created_at) }
+      )
+      .setFooter({ text: 'Translated from '+language+' with love by CodeMonkey'})
+
+    message.reply({ embeds: [embed]})
+    logger.info('[TRANSLATION] server='+message.channel.guild.name+', source=twitter, srcLanguage='+language+', user='+userData.username+', id='+tweetData.id)
+  })
+}
 
 exports.doTwitterLinksExistInContent = doTwitterLinksExistInContent;
 exports.getDistinctTwitterLinksInContent = getDistinctTwitterLinksInContent;


### PR DESCRIPTION
This PR accomplishes the following:
1. Updates us to use the newer v2 Twitter API. (This definitely wasn't forced by suddenly being locked out of v1.1)
2. Simplified language identification in the twitter translator path, now that we can fetch the language along with the tweet.

NOTE TO SELF: We are currently subject to twitter's 500k tweet limit on the ProjectOwl instance. We will need to monitor this, but 500k is INCREDIBLY high.