### PR TITLE
Disable the twitter API route

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@
 ## Shameless Plug
 This bot was written to support the awesome activities going on in the Project Owl Discord. If you want to see this thing in action, and have an interest in learning more and/or discussing geopolitical events around the globe, come join us! https://discord.gg/projectowl
 
+# Important Note
+
+Unfortunately, due to Twitter's API pricing changes in 2023, I am unable to continue to pay (both financially and morally) for twitter's API access. For this reason, I have commented out the codepath that called the Twitter API, and regrettably have diverted twitter handling to the embed processor at this time. Folks are welcome to fork and uncomment the code, but I will not be using it going forward.
+
+GG BOIS.
+
 ## Overview
 This project is a Discord bot that listens to a discord server for messages containing links, and responds to them with translated links in english with a formatted embedded message.
 

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,6 @@
 var Winston = require('winston');
 var config = require('./config/config.json');
-var twitterTranslator = require('./translators/twitter');
+// var twitterTranslator = require('./translators/twitter');
 var embedTranslator = require('./translators/embeds');
 const { Client, GatewayIntentBits } = require('discord.js');
 const {Translate} = require('@google-cloud/translate').v2;
@@ -77,6 +77,11 @@ client.on('messageCreate', async function(message) {
 
 async function processMessageTranslations(message) {
   
+  // Due to twitter's API shenanigans, I cannot afford keep the twitter-API based route active
+  // This code is commented in the hopes that Discord is willing to pay for embed privileges on their side.
+  // Otherwise, this bot is hosed. GG bois.
+
+  /**
   if (twitterTranslator.doTwitterLinksExistInContent(message) && config.translation.twitter) {
 
     // Check rate limiter
@@ -91,6 +96,7 @@ async function processMessageTranslations(message) {
 
     return
   }
+  */
 
   if (config.translation.anyEmbed && linkParser.containsAnyLink(message.content)) {
 


### PR DESCRIPTION
Unfortunately, Twitter began enforcing their rather API changes on my account, which has led to me being unable to maintain the api-based approach to action translations of tweets.

This PR disables the twitter api-based path, and handles everything by translating embeds from discord instead.

PLEASE NOTE: Should Discord stop embedding tweets due to it's own cost concerns, I cannot guarantee translations of tweets going forward.

GG bois, someone find us a new home to play and chat.